### PR TITLE
Fix lint

### DIFF
--- a/asyncpg_listen/listener.py
+++ b/asyncpg_listen/listener.py
@@ -2,7 +2,7 @@ import asyncio
 import dataclasses
 import enum
 import logging
-from typing import Any, Awaitable, Callable, Dict, Optional, Union
+from typing import Any, Callable, Coroutine, Dict, Optional, Union
 
 import async_timeout
 import asyncpg
@@ -33,9 +33,9 @@ class Notification:
     payload: Optional[str]
 
 
-ConnectFunc = Callable[[], Awaitable[asyncpg.Connection]]
+ConnectFunc = Callable[[], Coroutine[Any, Any, asyncpg.Connection]]
 NotificationOrTimeout = Union[Notification, Timeout]
-NotificationHandler = Callable[[NotificationOrTimeout], Awaitable]
+NotificationHandler = Callable[[NotificationOrTimeout], Coroutine]
 
 NO_TIMEOUT: float = -1
 


### PR DESCRIPTION
```
asyncpg_listen/listener.py:124: error: Argument 1 to "create_task" has incompatible type "Awaitable[Any]"; expected "Union[Generator[Any, None, <nothing>], Coroutine[Any, Any, <nothing>]]"
Found 1 error in 1 file (checked 2 source files)
make: *** [mypy] Error 1
```