### PR TITLE
SELECT 1 only if we haven't seen any events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## unreleased
+
+# [SELECT 1 only if we haven't seen any events](https://github.com/anna-money/asyncpg-listen/pull/222)
+
+
 ## v0.0.8 (2025-05-25)
 
 * Support python 3.13

--- a/asyncpg_listen/listener.py
+++ b/asyncpg_listen/listener.py
@@ -150,7 +150,8 @@ class NotificationListener:
                             await connection.execute("SELECT 1", timeout=per_attempt_keep_alive_budget)
                         event.clear()
                         finished_at = time.monotonic()
-                        if (elapsed := finished_at - started_at) and elapsed < per_attempt_keep_alive_budget:
+                        elapsed = finished_at - started_at
+                        if elapsed < per_attempt_keep_alive_budget:
                             await asyncio.sleep(per_attempt_keep_alive_budget - elapsed)
                     logger.warning("Connection was lost")
                 finally:

--- a/asyncpg_listen/listener.py
+++ b/asyncpg_listen/listener.py
@@ -46,7 +46,6 @@ class NotificationListener:
     __slots__ = (
         "__connect",
         "__reconnect_delay",
-        "__tasks",
     )
 
     def __init__(self, connect: ConnectFunc, reconnect_delay: float = 5) -> None:

--- a/asyncpg_listen/listener.py
+++ b/asyncpg_listen/listener.py
@@ -157,7 +157,7 @@ class NotificationListener:
                 finally:
                     await asyncio.shield(connection.close())
             except Exception:
-                if failed_connect_attempts < 3:
+                if failed_connect_attempts < MAX_FAILED_CONNECT_ATTEMPTS:
                     logger.warning("Connection was lost or not established", exc_info=True)
                 else:
                     logger.exception("Connection was lost or not established")

--- a/asyncpg_listen/listener.py
+++ b/asyncpg_listen/listener.py
@@ -32,6 +32,7 @@ NotificationOrTimeout = Notification | Timeout
 NotificationHandler = Callable[[NotificationOrTimeout], Coroutine]
 
 NO_TIMEOUT: float = -1
+MAX_SILENCED_FAILED_CONNECT_ATTEMPTS = 3
 
 
 def connect_func(*args: Any, **kwargs: Any) -> ConnectFunc:
@@ -157,7 +158,7 @@ class NotificationListener:
                 finally:
                     await asyncio.shield(connection.close())
             except Exception:
-                if failed_connect_attempts < MAX_FAILED_CONNECT_ATTEMPTS:
+                if failed_connect_attempts < MAX_SILENCED_FAILED_CONNECT_ATTEMPTS:
                     logger.warning("Connection was lost or not established", exc_info=True)
                 else:
                     logger.exception("Connection was lost or not established")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 pytest==8.3.4
 pytest-aiohttp==1.0.5
-pytest-pg==0.0.21
+pytest-pg==0.0.25
 pytest-runner==6.0.1
 pytest-asyncio==0.24.0
 isort==5.13.2


### PR DESCRIPTION
It might be slightly silly to ping PG every notification_timeout/3 seconds just to ensure that a connection is alive. 

Instead, we could monitor if we saw a notification arrived since last check.

Also, some additional critical points have been addressed:
1. We use a timeout to execute SELECT 1.
2. We carefully monitor real time cost to execute SELECT 1.
3. If we already know that a connection is closed then we should just stop and reestablish it.

As a final bit, we also could stop logging errors for the <= 3 unsuccessful connection attempts in a row.